### PR TITLE
Camera Flash

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -370,7 +370,7 @@
 	. = ..()
 	. += span_notice("It has [current_charges] charge\s remaining.")
 	if (length(charge_timers))
-		. += "[span_boldnotice("A small display on the screen reads:")]"
+		. += span_boldnotice("A small display on the screen reads:")
 	for (var/i in 1 to length(charge_timers))
 		var/timeleft = timeleft(charge_timers[i])
 		var/loadingbar = num2loadingbar(timeleft/charge_time)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -323,7 +323,6 @@
 /obj/item/assembly/flash/cyborg/screwdriver_act(mob/living/user, obj/item/I)
 	return
 
-
 ///Camera flash
 
 /obj/item/assembly/flash/camera
@@ -332,30 +331,37 @@
 	desc = "A polaroid camera."
 	icon_state = "camera"
 	inhand_icon_state = "camera"
-	worn_icon_state = "camera"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
-	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_NECK
-	pickup_sound = null
+	pickup_sound = null //override pickup and drop sounds so it behaves more like a real camera.
+	drop_sound = null
 	flash_sound = 'sound/items/polaroid1.ogg'
 	var/max_charges = 5
 	var/current_charges = 5
 	var/list/charge_timers = list()
-	var/charge_time = 300 //30 seconds
+	var/charge_time = 30 SECONDS
 
 /obj/item/assembly/flash/camera/burn_out()
 	return //use self charging system instead
 
-/obj/item/assembly/flash/camera/attack(mob/living/M, mob/user)
+/obj/item/assembly/flash/camera/attack_self(mob/living/carbon/user, flag = 0)
 	if(current_charges)
-		current_charges --
-		to_chat(user, span_notice("You use [src]. It now has [current_charges] charge[current_charges == 1 ? "" : "s"] remaining."))
+		current_charges--
+		to_chat(user, span_notice("You use [src]. It now has [current_charge\s] charges remaining."))
 		charge_timers.Add(addtimer(CALLBACK(src, .proc/recharge), charge_time, TIMER_STOPPABLE))
 		..()
 	else
 		to_chat(user, span_warning("[src] is recharging."))
-	return
+
+/obj/item/assembly/flash/camera/attack(mob/living/M, mob/user)
+	if(current_charges)
+		current_charges--
+		to_chat(user, span_notice("You use [src]. It now has [current_charges] charge\s remaining."))
+		charge_timers.Add(addtimer(CALLBACK(src, .proc/recharge), charge_time, TIMER_STOPPABLE))
+		..()
+	else
+		to_chat(user, span_warning("[src] is recharging."))
 
 /obj/item/assembly/flash/camera/proc/recharge(mob/user)
 	current_charges = min(current_charges+1, max_charges)
@@ -363,13 +369,13 @@
 
 /obj/item/assembly/flash/camera/examine(mob/user)
 	. = ..()
-	. += span_notice("It has [current_charges] charges remaining.")
+	. += span_notice("It has [current_charges] charge\s remaining.")
 	if (length(charge_timers))
-		. += "[span_notice("<b>A small display on the screen reads:")]</b>"
+		. += "[span_boldnotice("<b>A small display on the screen reads:")]</b>"
 	for (var/i in 1 to length(charge_timers))
 		var/timeleft = timeleft(charge_timers[i])
 		var/loadingbar = num2loadingbar(timeleft/charge_time)
-		. += span_notice("<b>CHARGE #[i]: [loadingbar] ([timeleft*0.1]s)</b>")
+		. += span_boldnotice("<b>CHARGE #[i]: [loadingbar] ([timeleft*0.1]s)</b>")
 
 //Memorizer
 

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -32,6 +32,7 @@
 	var/last_used = 0 //last world.time it was used.
 	var/cooldown = 0
 	var/last_trigger = 0 //Last time it was successfully triggered.
+	var/flash_sound = 'sound/weapons/flash.ogg' //For custom sounds when the flash is used.
 
 /obj/item/assembly/flash/suicide_act(mob/living/user)
 	if(burnt_out)
@@ -115,7 +116,7 @@
 	if(burnt_out || (world.time < last_trigger + cooldown))
 		return FALSE
 	last_trigger = world.time
-	playsound(src, 'sound/weapons/flash.ogg', 100, TRUE)
+	playsound(src, flash_sound, 100, TRUE)
 	set_light_on(TRUE)
 	addtimer(CALLBACK(src, .proc/flash_end), FLASH_LIGHT_DURATION, TIMER_OVERRIDE|TIMER_UNIQUE)
 	times_used++
@@ -322,6 +323,56 @@
 /obj/item/assembly/flash/cyborg/screwdriver_act(mob/living/user, obj/item/I)
 	return
 
+
+///Camera flash
+
+/obj/item/assembly/flash/camera
+	name = "camera"
+	icon = 'icons/obj/items_and_weapons.dmi'
+	desc = "A polaroid camera."
+	icon_state = "camera"
+	inhand_icon_state = "camera"
+	worn_icon_state = "camera"
+	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
+	flags_1 = CONDUCT_1
+	slot_flags = ITEM_SLOT_NECK
+	pickup_sound = null
+	flash_sound = 'sound/items/polaroid1.ogg'
+	var/max_charges = 5
+	var/current_charges = 5
+	var/list/charge_timers = list()
+	var/charge_time = 300 //30 seconds
+
+/obj/item/assembly/flash/camera/burn_out()
+	return //use self charging system instead
+
+/obj/item/assembly/flash/camera/attack(mob/living/M, mob/user)
+	if(current_charges)
+		current_charges --
+		to_chat(user, span_notice("You use [src]. It now has [current_charges] charge[current_charges == 1 ? "" : "s"] remaining."))
+		charge_timers.Add(addtimer(CALLBACK(src, .proc/recharge), charge_time, TIMER_STOPPABLE))
+		..()
+	else
+		to_chat(user, span_warning("[src] is recharging."))
+	return
+
+/obj/item/assembly/flash/camera/proc/recharge(mob/user)
+	current_charges = min(current_charges+1, max_charges)
+	charge_timers.Remove(charge_timers[1])
+
+/obj/item/assembly/flash/camera/examine(mob/user)
+	. = ..()
+	. += span_notice("It has [current_charges] charges remaining.")
+	if (length(charge_timers))
+		. += "[span_notice("<b>A small display on the screen reads:")]</b>"
+	for (var/i in 1 to length(charge_timers))
+		var/timeleft = timeleft(charge_timers[i])
+		var/loadingbar = num2loadingbar(timeleft/charge_time)
+		. += span_notice("<b>CHARGE #[i]: [loadingbar] ([timeleft*0.1]s)</b>")
+
+//Memorizer
+
 /obj/item/assembly/flash/memorizer
 	name = "memorizer"
 	desc = "If you see this, you're not likely to remember it any time soon."
@@ -355,7 +406,7 @@
 		return FALSE
 	overheat = TRUE
 	addtimer(CALLBACK(src, .proc/cooldown), flashcd)
-	playsound(src, 'sound/weapons/flash.ogg', 100, TRUE)
+	playsound(src, flash_sound, 100, TRUE)
 	update_icon(ALL, TRUE)
 	return TRUE
 

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -346,20 +346,19 @@
 	return //use self charging system instead
 
 /obj/item/assembly/flash/camera/attack_self(mob/living/carbon/user, flag = 0)
-	if(current_charges)
-		current_charges--
-		to_chat(user, span_notice("You use [src]. It now has [current_charge\s] charges remaining."))
-		charge_timers.Add(addtimer(CALLBACK(src, .proc/recharge), charge_time, TIMER_STOPPABLE))
-		..()
-	else
-		to_chat(user, span_warning("[src] is recharging."))
+	if(use_charge(user))
+		. = ..()
 
 /obj/item/assembly/flash/camera/attack(mob/living/M, mob/user)
+	if(use_charge(user))
+		. = ..()
+
+/obj/item/assembly/flash/camera/proc/use_charge(mob/user)
 	if(current_charges)
 		current_charges--
 		to_chat(user, span_notice("You use [src]. It now has [current_charges] charge\s remaining."))
 		charge_timers.Add(addtimer(CALLBACK(src, .proc/recharge), charge_time, TIMER_STOPPABLE))
-		..()
+		return TRUE
 	else
 		to_chat(user, span_warning("[src] is recharging."))
 
@@ -371,11 +370,11 @@
 	. = ..()
 	. += span_notice("It has [current_charges] charge\s remaining.")
 	if (length(charge_timers))
-		. += "[span_boldnotice("<b>A small display on the screen reads:")]</b>"
+		. += "[span_boldnotice("A small display on the screen reads:")]"
 	for (var/i in 1 to length(charge_timers))
 		var/timeleft = timeleft(charge_timers[i])
 		var/loadingbar = num2loadingbar(timeleft/charge_time)
-		. += span_boldnotice("<b>CHARGE #[i]: [loadingbar] ([timeleft*0.1]s)</b>")
+		. += span_boldnotice("CHARGE #[i]: [loadingbar] ([timeleft*0.1]s)")
 
 //Memorizer
 

--- a/code/modules/uplink/uplink_items/stealthy.dm
+++ b/code/modules/uplink/uplink_items/stealthy.dm
@@ -8,6 +8,14 @@
 
 // No progression cost
 
+/datum/uplink_item/stealthy_weapons/camera_flash
+	name = "Camera Flash"
+	desc = "A flash disguised as a camera with a self-charging safety system preventing the flash from burning out.\
+			 Due to its design, this flash cannot be overcharged like regular flashes can.\
+			 Useful for stunning borgs and individuals without eye protection or blinding a crowd for a get away."
+	item = /obj/item/assembly/flash/camera
+	cost = 1
+
 /datum/uplink_item/stealthy_weapons/dart_pistol
 	name = "Dart Pistol"
 	desc = "A miniaturized version of a normal syringe gun. It is very quiet when fired and can fit into any \

--- a/code/modules/uplink/uplink_items/stealthy.dm
+++ b/code/modules/uplink/uplink_items/stealthy.dm
@@ -10,9 +10,9 @@
 
 /datum/uplink_item/stealthy_weapons/camera_flash
 	name = "Camera Flash"
-	desc = "A flash disguised as a camera with a self-charging safety system preventing the flash from burning out.\
-			 Due to its design, this flash cannot be overcharged like regular flashes can.\
-			 Useful for stunning borgs and individuals without eye protection or blinding a crowd for a get away."
+	desc = "A flash disguised as a camera with a self-charging safety system preventing the flash from burning out. \
+	        Due to its design, this flash cannot be overcharged like regular flashes can. \
+	        Useful for stunning borgs and individuals without eye protection or blinding a crowd for a get away."
 	item = /obj/item/assembly/flash/camera
 	cost = 1
 


### PR DESCRIPTION
## About The Pull Request

Adds the camera flash, a cheap uplink item ported from Paradise station with code updated to /tg/.

Works and looks just like an ordinary camera, but secretly functions as a flash. 

## Why It's Good For The Game

I like this item so much I just had to port it.

## Changelog

:cl: DarkMight9, Cenrus
add: Added Camera Flash to uplink
/:cl: